### PR TITLE
Link investigator&crime case list Fixes #108

### DIFF
--- a/src/main/java/seedu/investigapptor/logic/commands/AddCaseCommand.java
+++ b/src/main/java/seedu/investigapptor/logic/commands/AddCaseCommand.java
@@ -21,6 +21,7 @@ import seedu.investigapptor.model.crimecase.StartDate;
 import seedu.investigapptor.model.crimecase.Status;
 import seedu.investigapptor.model.crimecase.exceptions.DuplicateCrimeCaseException;
 import seedu.investigapptor.model.person.Person;
+import seedu.investigapptor.model.person.investigator.Investigator;
 import seedu.investigapptor.model.tag.Tag;
 
 /**
@@ -108,14 +109,19 @@ public class AddCaseCommand extends UndoableCommand {
             }
 
             Person investigatorToAdd = lastShownList.get(investigatorIndex.getZeroBased());
-            toAdd = createCrimeCase(investigatorToAdd);
+            if (investigatorToAdd instanceof Investigator) {
+                toAdd = createCrimeCase((Investigator) investigatorToAdd);
+            } else {
+                throw new CommandException("Selected personal is not an investigator");
+            }
+
         }
     }
 
     /**
      * Creates and returns a {@code CrimeCase} with the details of {@code investigatorToAdd}
      */
-    private CrimeCase createCrimeCase(Person investigatorToAdd) {
+    private CrimeCase createCrimeCase(Investigator investigatorToAdd) {
         assert investigatorToAdd != null;
 
         return new CrimeCase(this.name, this.description, investigatorToAdd,

--- a/src/main/java/seedu/investigapptor/logic/commands/AddCaseCommand.java
+++ b/src/main/java/seedu/investigapptor/logic/commands/AddCaseCommand.java
@@ -107,14 +107,12 @@ public class AddCaseCommand extends UndoableCommand {
             if (investigatorIndex.getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_INVESTIGATOR_DISPLAYED_INDEX);
             }
-
             Person investigatorToAdd = lastShownList.get(investigatorIndex.getZeroBased());
             if (investigatorToAdd instanceof Investigator) {
                 toAdd = createCrimeCase((Investigator) investigatorToAdd);
             } else {
                 throw new CommandException("Selected personal is not an investigator");
             }
-
         }
     }
 

--- a/src/main/java/seedu/investigapptor/logic/commands/DeleteInvestigatorCommand.java
+++ b/src/main/java/seedu/investigapptor/logic/commands/DeleteInvestigatorCommand.java
@@ -10,6 +10,7 @@ import seedu.investigapptor.commons.core.index.Index;
 import seedu.investigapptor.logic.commands.exceptions.CommandException;
 import seedu.investigapptor.model.person.Person;
 import seedu.investigapptor.model.person.exceptions.PersonNotFoundException;
+import seedu.investigapptor.model.person.investigator.Investigator;
 
 /**
  * Deletes a person identified using it's last displayed index from the investigapptor book.
@@ -25,7 +26,8 @@ public class DeleteInvestigatorCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Investigator: %1$s";
-
+    public static final String MESSAGE_ACTIVE_INVESTIGATOR = "Investigator is currently in charge of a case.\n"
+            + "Please reassign the cases to another investigator to delete the selected investigator";
     private final Index targetIndex;
 
     private Person personToDelete;
@@ -36,14 +38,19 @@ public class DeleteInvestigatorCommand extends UndoableCommand {
 
 
     @Override
-    public CommandResult executeUndoableCommand() {
+    public CommandResult executeUndoableCommand() throws CommandException {
         requireNonNull(personToDelete);
-        try {
-            model.deletePerson(personToDelete);
-        } catch (PersonNotFoundException pnfe) {
-            throw new AssertionError("The target investigator cannot be missing");
+        if (personToDelete instanceof Investigator) {
+            if (!((Investigator) personToDelete).emptyList()) {
+                throw new CommandException(MESSAGE_ACTIVE_INVESTIGATOR);
+            }
+        } else {
+            try {
+                model.deletePerson(personToDelete);
+            } catch (PersonNotFoundException pnfe) {
+                throw new AssertionError("The target investigator cannot be missing");
+            }
         }
-
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/investigapptor/model/Investigapptor.java
+++ b/src/main/java/seedu/investigapptor/model/Investigapptor.java
@@ -145,6 +145,27 @@ public class Investigapptor implements ReadOnlyInvestigapptor {
         }
     }
 
+    /**
+     * Converts {@code key} hashcode list of cases into CrimeCase object
+     *
+     *
+     */
+    public void convertHashToCases(Investigator key) throws DuplicatePersonException {
+        if (key.getCaseListHashed() != null) {
+            for (Integer i : key.getCaseListHashed()) {
+                for (CrimeCase c : cases) {
+                    if (c.hashCode() == i) {
+                        try {
+                            key.addCrimeCase(c);
+                        } catch (DuplicateCrimeCaseException e) {
+                            throw new AssertionError("Not possible, duplicate case while retrieving from xml");
+                        }
+                    }
+                }
+            }
+        }
+        addPerson(key);
+    }
     //// case-level operations
 
     /**
@@ -159,7 +180,9 @@ public class Investigapptor implements ReadOnlyInvestigapptor {
         // TODO: the tags master list will be updated even though the below line fails.
         // This can cause the tags master list to have additional tags that are not tagged to any case
         // in the case list.
-        cases.add(crimecase);
+        if (cases.add(crimecase)) {
+            crimecase.getCurrentInvestigator().addCrimeCase(crimecase);
+        }
     }
 
     //// tag-level operations

--- a/src/main/java/seedu/investigapptor/model/Investigapptor.java
+++ b/src/main/java/seedu/investigapptor/model/Investigapptor.java
@@ -181,7 +181,9 @@ public class Investigapptor implements ReadOnlyInvestigapptor {
         // This can cause the tags master list to have additional tags that are not tagged to any case
         // in the case list.
         if (cases.add(crimecase)) {
-            crimecase.getCurrentInvestigator().addCrimeCase(crimecase);
+            if (crimecase.getCurrentInvestigator() != null) {
+                crimecase.getCurrentInvestigator().addCrimeCase(crimecase);
+            }
         }
     }
 

--- a/src/main/java/seedu/investigapptor/model/Investigapptor.java
+++ b/src/main/java/seedu/investigapptor/model/Investigapptor.java
@@ -182,6 +182,9 @@ public class Investigapptor implements ReadOnlyInvestigapptor {
         // in the case list.
         if (cases.add(crimecase)) {
             if (crimecase.getCurrentInvestigator() != null) {
+                for (CrimeCase d : crimecase.getCurrentInvestigator().getCrimeCases()) {
+                    System.out.println(d.getCaseName());
+                }
                 crimecase.getCurrentInvestigator().addCrimeCase(crimecase);
             }
         }

--- a/src/main/java/seedu/investigapptor/model/crimecase/CrimeCase.java
+++ b/src/main/java/seedu/investigapptor/model/crimecase/CrimeCase.java
@@ -5,7 +5,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import seedu.investigapptor.model.person.Person;
+import seedu.investigapptor.model.person.investigator.Investigator;
 import seedu.investigapptor.model.tag.Tag;
 import seedu.investigapptor.model.tag.UniqueTagList;
 
@@ -17,7 +17,7 @@ public class CrimeCase {
 
     private final CaseName name;
     private final Description description;
-    private final Person currentInvestigator;
+    private final Investigator currentInvestigator;
     private final StartDate startDate;
     private final Status status;
 
@@ -26,7 +26,7 @@ public class CrimeCase {
     /**
      * Every field must be present and not null
      */
-    public CrimeCase(CaseName name, Description description, Person currentInvestigator,
+    public CrimeCase(CaseName name, Description description, Investigator currentInvestigator,
                      StartDate startDate, Status status, Set<Tag> tags) {
         this.name = name;
         this.description = description;
@@ -44,7 +44,7 @@ public class CrimeCase {
         return description;
     }
 
-    public Person getCurrentInvestigator() {
+    public Investigator getCurrentInvestigator() {
         return currentInvestigator;
     }
 
@@ -103,7 +103,7 @@ public class CrimeCase {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, description, currentInvestigator, startDate, status, tags);
+        return Objects.hash(name, startDate, status, tags);
     }
 
     @Override
@@ -113,7 +113,7 @@ public class CrimeCase {
                 .append(" Description: ")
                 .append(getDescription())
                 .append(" Current Investigator: ")
-                .append(getCurrentInvestigator())
+                .append(getCurrentInvestigator().getName())
                 .append(" Start Date: ")
                 .append(getStartDate())
                 .append(" Status: ")

--- a/src/main/java/seedu/investigapptor/model/crimecase/UniqueCrimeCaseList.java
+++ b/src/main/java/seedu/investigapptor/model/crimecase/UniqueCrimeCaseList.java
@@ -48,12 +48,13 @@ public class UniqueCrimeCaseList implements Iterable<CrimeCase> {
      *
      * @throws DuplicateCrimeCaseException if the person to add is a duplicate of an existing person in the list.
      */
-    public void add(CrimeCase toAdd) throws DuplicateCrimeCaseException {
+    public boolean add(CrimeCase toAdd) throws DuplicateCrimeCaseException {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicateCrimeCaseException();
         }
         internalList.add(toAdd);
+        return true;
     }
 
     /**

--- a/src/main/java/seedu/investigapptor/model/person/investigator/Investigator.java
+++ b/src/main/java/seedu/investigapptor/model/person/investigator/Investigator.java
@@ -1,5 +1,6 @@
 package seedu.investigapptor.model.person.investigator;
 
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Set;
 
@@ -23,6 +24,7 @@ public class Investigator extends Person {
 
     private UniqueCrimeCaseList crimeCases;
     private Rank rank;
+    private ArrayList<Integer> caseListHashed;
     /**
      * Every field must be present and not null.
      */
@@ -36,6 +38,13 @@ public class Investigator extends Person {
         super(name, phone, email, address, tags);
         this.rank = rank;
         crimeCases = new UniqueCrimeCaseList(cases);
+    }
+    public Investigator(Name name, Phone phone, Email email, Address address, Rank rank,
+                        Set<Tag> tags, ArrayList<Integer> caseListHashed) {
+        super(name, phone, email, address, tags);
+        this.rank = rank;
+        crimeCases = new UniqueCrimeCaseList();
+        this.caseListHashed = caseListHashed;
     }
     public void addCrimeCase(CrimeCase caseToAdd) throws DuplicateCrimeCaseException {
         crimeCases.add(caseToAdd);
@@ -71,14 +80,29 @@ public class Investigator extends Person {
         return crimeCases.asObservableList();
     }
 
+    /**
+     * Returns true if empty
+     * else if not empty
+     */
+    public boolean emptyList() {
+        if (getCrimeCases().isEmpty()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public void removeCrimeCase(CrimeCase caseToRemove) throws CrimeCaseNotFoundException {
         crimeCases.remove(caseToRemove);
     }
 
+    public ArrayList<Integer> getCaseListHashed() {
+        return caseListHashed;
+    }
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, rank, tags, crimeCases);
+        return Objects.hash(name, phone, email, address, rank, tags);
     }
 
     @Override

--- a/src/main/java/seedu/investigapptor/storage/XmlAdaptedCrimeCase.java
+++ b/src/main/java/seedu/investigapptor/storage/XmlAdaptedCrimeCase.java
@@ -15,6 +15,7 @@ import seedu.investigapptor.model.crimecase.Description;
 import seedu.investigapptor.model.crimecase.StartDate;
 import seedu.investigapptor.model.crimecase.Status;
 import seedu.investigapptor.model.person.Person;
+import seedu.investigapptor.model.person.investigator.Investigator;
 import seedu.investigapptor.model.tag.Tag;
 
 /**
@@ -29,7 +30,7 @@ public class XmlAdaptedCrimeCase {
     @XmlElement(required = true)
     private String description;
     @XmlElement(required = true)
-    private XmlAdaptedPerson investigator;
+    private XmlAdaptedInvestigator investigator;
     @XmlElement(required = true)
     private String startDate;
     @XmlElement(required = true)
@@ -47,7 +48,7 @@ public class XmlAdaptedCrimeCase {
     /**
      * Constructs an {@code XmlAdaptedCrimeCase} with the given case details.
      */
-    public XmlAdaptedCrimeCase(String name, String description, XmlAdaptedPerson investigator, String startDate,
+    public XmlAdaptedCrimeCase(String name, String description, XmlAdaptedInvestigator investigator, String startDate,
                                String status, List<XmlAdaptedTag> tagged) {
         this.name = name;
         this.description = description;
@@ -67,7 +68,7 @@ public class XmlAdaptedCrimeCase {
     public XmlAdaptedCrimeCase(CrimeCase source) {
         name = source.getCaseName().crimeCaseName;
         description = source.getDescription().description;
-        investigator = new XmlAdaptedPerson(source.getCurrentInvestigator());
+        investigator = new XmlAdaptedInvestigator(source.getCurrentInvestigator());
         startDate = source.getStartDate().date;
         status = source.getStatus().toString();
         tagged = new ArrayList<>();
@@ -108,7 +109,7 @@ public class XmlAdaptedCrimeCase {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     Person.class.getSimpleName()));
         }
-        final Person investigator = this.investigator.toModelType();
+        final Investigator investigator = this.investigator.toModelType();
 
         if (this.startDate == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,

--- a/src/main/java/seedu/investigapptor/storage/XmlAdaptedInvestigator.java
+++ b/src/main/java/seedu/investigapptor/storage/XmlAdaptedInvestigator.java
@@ -38,7 +38,7 @@ public class XmlAdaptedInvestigator {
     @XmlElement(required = true)
     private String rank;
     @XmlElement(required = true)
-    private List<XmlAdaptedCrimeCase> caseList = new ArrayList<>();
+    private List<Integer> caseList = new ArrayList<>();
 
     @XmlElement
     private List<XmlAdaptedTag> tagged = new ArrayList<>();
@@ -53,14 +53,17 @@ public class XmlAdaptedInvestigator {
      * Constructs an {@code XmlAdaptedPerson} with the given person details.
      */
     public XmlAdaptedInvestigator(String name, String phone, String email, String address, String rank,
-                                  List<XmlAdaptedCrimeCase> caseList, List<XmlAdaptedTag> tagged) {
+                                  List<CrimeCase> caseList, List<XmlAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.rank = rank;
+        this.caseList = new ArrayList<>();
         if (caseList != null) {
-            this.caseList = new ArrayList<>(caseList);
+            for (CrimeCase c : caseList) {
+                this.caseList.add(c.hashCode());
+            }
         }
         if (tagged != null) {
             this.tagged = new ArrayList<>(tagged);
@@ -80,7 +83,7 @@ public class XmlAdaptedInvestigator {
         rank = source.getRank().getValue();
         caseList = new ArrayList<>();
         for (CrimeCase crimeCase : source.getCrimeCases()) {
-            caseList.add(new XmlAdaptedCrimeCase(crimeCase));
+            caseList.add(crimeCase.hashCode());
         }
         tagged = new ArrayList<>();
         for (Tag tag : source.getTags()) {
@@ -99,9 +102,9 @@ public class XmlAdaptedInvestigator {
             personTags.add(tag.toModelType());
         }
 
-        final List<CrimeCase> investigatorCases = new ArrayList<>();
-        for (XmlAdaptedCrimeCase crimeCase: caseList) {
-            investigatorCases.add(crimeCase.toModelType());
+        final ArrayList<Integer> investigatorCases = new ArrayList<>();
+        for (int crimeCase: caseList) {
+            investigatorCases.add(crimeCase);
         }
         if (this.name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
@@ -144,8 +147,7 @@ public class XmlAdaptedInvestigator {
         final Rank rank = new Rank(this.rank);
 
         final Set<Tag> tags = new HashSet<>(personTags);
-        final Set<CrimeCase> crimeCases = new HashSet<>(investigatorCases);
-        return new Investigator(name, phone, email, address, rank, tags, crimeCases);
+        return new Investigator(name, phone, email, address, rank, tags, investigatorCases);
     }
 
     /**

--- a/src/main/java/seedu/investigapptor/storage/XmlSerializableInvestigapptor.java
+++ b/src/main/java/seedu/investigapptor/storage/XmlSerializableInvestigapptor.java
@@ -10,6 +10,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import seedu.investigapptor.commons.exceptions.IllegalValueException;
 import seedu.investigapptor.model.Investigapptor;
 import seedu.investigapptor.model.ReadOnlyInvestigapptor;
+import seedu.investigapptor.model.person.investigator.Investigator;
 
 /**
  * An Immutable Investigapptor that is serializable to XML format
@@ -67,7 +68,10 @@ public class XmlSerializableInvestigapptor {
             investigapptor.addPerson(p.toModelType());
         }
         for (XmlAdaptedInvestigator i : investigators) {
-            investigapptor.addPerson(i.toModelType());
+            Investigator investigator = i.toModelType();
+            investigapptor.convertHashToCases(investigator);
+            //investigapptor.addPerson(investigator);
+
         }
         return investigapptor;
     }

--- a/src/test/data/XmlSerializableInvestigapptorTest/typicalCrimeCasesInvestigapptor.xml
+++ b/src/test/data/XmlSerializableInvestigapptorTest/typicalCrimeCasesInvestigapptor.xml
@@ -10,6 +10,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>10/11/2015</startDate>
@@ -24,6 +25,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>12/03/2016</startDate>
@@ -39,6 +41,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>18/01/2012</startDate>
@@ -53,6 +56,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>27/11/1999</startDate>
@@ -66,6 +70,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>23/11/1965</startDate>
@@ -79,6 +84,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>09/07/2017</startDate>
@@ -92,6 +98,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>02/08/2017</startDate>
@@ -105,6 +112,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>10/12/2016</startDate>
@@ -121,6 +129,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>14/12/2016</startDate>
@@ -137,6 +146,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>18/12/2016</startDate>
@@ -152,6 +162,7 @@
             <phone>85355255</phone>
             <email>alice@example.com</email>
             <address>123, Jurong West Ave 6, #08-111</address>
+			<rank>2</rank>
             <tagged>friends</tagged>
         </investigator>
         <startDate>11/12/2016</startDate>

--- a/src/test/data/XmlUtilTest/validInvestigapptor.xml
+++ b/src/test/data/XmlUtilTest/validInvestigapptor.xml
@@ -1,83 +1,66 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <investigapptor>
-    <persons>
-        <name>Hans Muster</name>
-        <phone isPrivate="false">9482424</phone>
-        <email isPrivate="false">hans@example.com</email>
-        <address isPrivate="false">4th street</address>
-    </persons>
-    <persons>
-        <name>Ruth Mueller</name>
-        <phone isPrivate="false">87249245</phone>
-        <email isPrivate="false">ruth@example.com</email>
-        <address isPrivate="false">81th street</address>
-    </persons>
-    <persons>
-        <name>Heinz Kurz</name>
-        <phone isPrivate="false">95352563</phone>
-        <email isPrivate="false">heinz@example.com</email>
-        <address isPrivate="false">wall street</address>
-    </persons>
-    <persons>
-        <name>Cornelia Meier</name>
-        <phone isPrivate="false">87652533</phone>
-        <email isPrivate="false">cornelia@example.com</email>
-        <address isPrivate="false">10th street</address>
-    </persons>
-    <persons>
-        <name>Werner Meyer</name>
-        <phone isPrivate="false">9482224</phone>
-        <email isPrivate="false">werner@example.com</email>
-        <address isPrivate="false">michegan ave</address>
-    </persons>
-    <persons>
-        <name>Lydia Kunz</name>
-        <phone isPrivate="false">9482427</phone>
-        <email isPrivate="false">lydia@example.com</email>
-        <address isPrivate="false">little tokyo</address>
-    </persons>
-    <persons>
-        <name>Anna Best</name>
-        <phone isPrivate="false">9482442</phone>
-        <email isPrivate="false">anna@example.com</email>
-        <address isPrivate="false">4th street</address>
-    </persons>
-    <persons>
-        <name>Stefan Meier</name>
-        <phone isPrivate="false">8482424</phone>
-        <email isPrivate="false">stefan@example.com</email>
-        <address isPrivate="false">little india</address>
-    </persons>
-    <persons>
-        <name>Martin Mueller</name>
-        <phone isPrivate="false">8482131</phone>
-        <email isPrivate="false">hans@example.com</email>
-        <address isPrivate="false">chicago ave</address>
-    </persons>
     <cases>
         <name>Project Three</name>
         <description>THREE!!</description>
         <investigator>
-            <name>Charlotte Oliveiro</name>
-            <phone>93210283</phone>
-            <email>charlotte@example.com</email>
-            <address>Blk 11 Ang Mo Kio Street 74, #11-04</address>
-            <tagged>neighbours</tagged>
+            <name>Heinz Kurz</name>
+            <phone>95352563</phone>
+            <email>jheinz@example.com</email>
+            <address>wall street</address>
+            <rank>2</rank>
+            <caseList>-1072334025</caseList>
+            <caseList>-1401203424</caseList>
         </investigator>
         <startDate>16/08/2010</startDate>
         <status>open</status>
+        <tagged>Three</tagged>
     </cases>
     <cases>
         <name>Other Three</name>
         <description>THREE!!</description>
         <investigator>
-            <name>Charlotte Oliveiro</name>
-            <phone>93210283</phone>
-            <email>charlotte@example.com</email>
-            <address>Blk 11 Ang Mo Kio Street 74, #11-04</address>
-            <tagged>neighbours</tagged>
+            <name>Heinz Kurz</name>
+            <phone>95352563</phone>
+            <email>jheinz@example.com</email>
+            <address>wall street</address>
+            <rank>2</rank>
+            <caseList>-1072334025</caseList>
+            <caseList>-1401203424</caseList>
         </investigator>
         <startDate>16/08/2010</startDate>
         <status>open</status>
+        <tagged>Three</tagged>
     </cases>
+    <tags>Three</tags>
+    <investigators>
+        <name>Hans Muster</name>
+        <phone>9482424</phone>
+        <email>jhans@example.com</email>
+        <address>4th street</address>
+        <rank>3</rank>
+    </investigators>
+    <investigators>
+        <name>Heinz Kurz</name>
+        <phone>95352563</phone>
+        <email>jheinz@example.com</email>
+        <address>wall street</address>
+        <rank>2</rank>
+        <caseList>-1072334025</caseList>
+        <caseList>-1401203424</caseList>
+    </investigators>
+    <investigators>
+        <name>Anna Best</name>
+        <phone>8382256</phone>
+        <email>anna@example.com</email>
+        <address>4th street</address>
+        <rank>3</rank>
+    </investigators>
+    <investigators>
+        <name>Martin Mueller</name>
+        <phone>9132356</phone>
+        <email>Martin@example.com</email>
+        <address>wall street</address>
+        <rank>5</rank>
+    </investigators>
 </investigapptor>

--- a/src/test/java/seedu/investigapptor/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/investigapptor/commons/util/XmlUtilTest.java
@@ -72,8 +72,8 @@ public class XmlUtilTest {
     public void getDataFromFile_validFile_validResult() throws Exception {
         Investigapptor dataFromFile = XmlUtil.getDataFromFile(VALID_FILE, XmlSerializableInvestigapptor.class)
                                         .toModelType();
-        assertEquals(9, dataFromFile.getPersonList().size());
-        assertEquals(0, dataFromFile.getTagList().size());
+        assertEquals(4, dataFromFile.getPersonList().size());
+        assertEquals(1, dataFromFile.getTagList().size());
     }
 
     @Test

--- a/src/test/java/seedu/investigapptor/logic/commands/AddCaseCommandIntegrationTest.java
+++ b/src/test/java/seedu/investigapptor/logic/commands/AddCaseCommandIntegrationTest.java
@@ -4,7 +4,7 @@ import static seedu.investigapptor.logic.commands.CommandTestUtil.assertCommandF
 import static seedu.investigapptor.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.investigapptor.testutil.TypicalCrimeCases.getTypicalInvestigapptor;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import seedu.investigapptor.logic.CommandHistory;
@@ -20,10 +20,10 @@ import seedu.investigapptor.testutil.CrimeCaseBuilder;
  */
 public class AddCaseCommandIntegrationTest {
 
-    private Model model;
+    private static Model model;
 
-    @Before
-    public void setUp() {
+    @BeforeClass
+    public static void setUp() {
         model = new ModelManager(getTypicalInvestigapptor(), new UserPrefs());
     }
 
@@ -34,7 +34,7 @@ public class AddCaseCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getInvestigapptor(), new UserPrefs());
         expectedModel.addCrimeCase(validCrimeCase);
 
-        assertCommandSuccess(prepareCommand(validCrimeCase, model), model,
+        assertCommandSuccess(prepareCommand(new CrimeCaseBuilder().build(), model), model,
                 String.format(AddCaseCommand.MESSAGE_SUCCESS, validCrimeCase), expectedModel);
     }
 

--- a/src/test/java/seedu/investigapptor/logic/commands/FindCaseCommandTest.java
+++ b/src/test/java/seedu/investigapptor/logic/commands/FindCaseCommandTest.java
@@ -28,7 +28,7 @@ import seedu.investigapptor.model.crimecase.CrimeCase;
  * Contains integration tests (interaction with the Model) for {@code FindCaseCommand}.
  */
 public class FindCaseCommandTest {
-    private Model model = new ModelManager(getTypicalInvestigapptor(), new UserPrefs());
+    private static Model model = new ModelManager(getTypicalInvestigapptor(), new UserPrefs());
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/investigapptor/logic/commands/FindCaseCommandTest.java
+++ b/src/test/java/seedu/investigapptor/logic/commands/FindCaseCommandTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import seedu.investigapptor.logic.CommandHistory;
@@ -28,7 +29,12 @@ import seedu.investigapptor.model.crimecase.CrimeCase;
  * Contains integration tests (interaction with the Model) for {@code FindCaseCommand}.
  */
 public class FindCaseCommandTest {
-    private static Model model = new ModelManager(getTypicalInvestigapptor(), new UserPrefs());
+    private Model model;
+
+    @Before
+    public void setUp() {
+        model = new ModelManager(getTypicalInvestigapptor(), new UserPrefs());
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/investigapptor/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/investigapptor/logic/commands/ListCommandTest.java
@@ -5,7 +5,7 @@ import static seedu.investigapptor.logic.commands.CommandTestUtil.showCaseAtInde
 import static seedu.investigapptor.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.investigapptor.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import seedu.investigapptor.logic.CommandHistory;
@@ -21,24 +21,24 @@ import seedu.investigapptor.testutil.TypicalPersons;
  */
 public class ListCommandTest {
 
-    private Model investigatorModel;
-    private Model expectedInvestigatorModel;
-    private ListCommand listCommandInvestigators;
+    private static Model investigatorModel;
+    private static Model expectedInvestigatorModel;
+    private static ListCommand listCommandInvestigators;
 
-    private Model investigatorAliasModel;
-    private Model expectedInvestigatorAliasModel;
-    private ListCommand listCommandInvestigatorAlias;
+    private static Model investigatorAliasModel;
+    private static Model expectedInvestigatorAliasModel;
+    private static ListCommand listCommandInvestigatorAlias;
 
-    private Model crimeCaseModel;
-    private Model expectedCrimeCaseModel;
-    private ListCommand listCommandCases;
+    private static Model crimeCaseModel;
+    private static Model expectedCrimeCaseModel;
+    private static ListCommand listCommandCases;
 
-    private Model crimeCaseAliasModel;
-    private Model expectedCrimeCaseAliasModel;
-    private ListCommand listCommandCrimeCaseAlias;
+    private static Model crimeCaseAliasModel;
+    private static Model expectedCrimeCaseAliasModel;
+    private static ListCommand listCommandCrimeCaseAlias;
 
-    @Before
-    public void setUp() {
+    @BeforeClass
+    public static void setUp() {
         investigatorModel = new ModelManager(TypicalPersons.getTypicalInvestigapptor(), new UserPrefs());
         expectedInvestigatorModel = new ModelManager(investigatorModel.getInvestigapptor(), new UserPrefs());
 

--- a/src/test/java/seedu/investigapptor/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/investigapptor/logic/commands/ListCommandTest.java
@@ -5,7 +5,7 @@ import static seedu.investigapptor.logic.commands.CommandTestUtil.showCaseAtInde
 import static seedu.investigapptor.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.investigapptor.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import seedu.investigapptor.logic.CommandHistory;
@@ -21,24 +21,24 @@ import seedu.investigapptor.testutil.TypicalPersons;
  */
 public class ListCommandTest {
 
-    private static Model investigatorModel;
-    private static Model expectedInvestigatorModel;
-    private static ListCommand listCommandInvestigators;
+    private Model investigatorModel;
+    private Model expectedInvestigatorModel;
+    private ListCommand listCommandInvestigators;
 
-    private static Model investigatorAliasModel;
-    private static Model expectedInvestigatorAliasModel;
-    private static ListCommand listCommandInvestigatorAlias;
+    private Model investigatorAliasModel;
+    private Model expectedInvestigatorAliasModel;
+    private ListCommand listCommandInvestigatorAlias;
 
-    private static Model crimeCaseModel;
-    private static Model expectedCrimeCaseModel;
-    private static ListCommand listCommandCases;
+    private Model crimeCaseModel;
+    private Model expectedCrimeCaseModel;
+    private ListCommand listCommandCases;
 
-    private static Model crimeCaseAliasModel;
-    private static Model expectedCrimeCaseAliasModel;
-    private static ListCommand listCommandCrimeCaseAlias;
+    private Model crimeCaseAliasModel;
+    private Model expectedCrimeCaseAliasModel;
+    private ListCommand listCommandCrimeCaseAlias;
 
-    @BeforeClass
-    public static void setUp() {
+    @Before
+    public void setUp() {
         investigatorModel = new ModelManager(TypicalPersons.getTypicalInvestigapptor(), new UserPrefs());
         expectedInvestigatorModel = new ModelManager(investigatorModel.getInvestigapptor(), new UserPrefs());
 

--- a/src/test/java/seedu/investigapptor/logic/parser/InvestigapptorParserTest.java
+++ b/src/test/java/seedu/investigapptor/logic/parser/InvestigapptorParserTest.java
@@ -52,8 +52,8 @@ public class InvestigapptorParserTest {
 
     @Test
     public void parseCommand_add() throws Exception {
-        Person person = new PersonBuilder().build();
-        CrimeCase crimeCase = new CrimeCaseBuilder().withInvestigator(person).build();
+        Investigator investigator = new InvestigatorBuilder().build();
+        CrimeCase crimeCase = new CrimeCaseBuilder().withInvestigator(investigator).build();
         AddCaseCommand command = (AddCaseCommand)
                 parser.parseCommand(CrimeCaseUtil.getAddCommand(crimeCase) + "i/" + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new AddCaseCommand(crimeCase.getCaseName(), crimeCase.getDescription(),
@@ -62,8 +62,8 @@ public class InvestigapptorParserTest {
 
     @Test
     public void parseCommand_addAlias() throws Exception {
-        Person person = new PersonBuilder().build();
-        CrimeCase crimeCase = new CrimeCaseBuilder().withInvestigator(person).build();
+        Investigator investigator = new InvestigatorBuilder().build();
+        CrimeCase crimeCase = new CrimeCaseBuilder().withInvestigator(investigator).build();
         AddCaseCommand command = (AddCaseCommand)
                 parser.parseCommand(CrimeCaseUtil.getAliasAddCommand(crimeCase)
                         + "i/" + INDEX_FIRST_PERSON.getOneBased());

--- a/src/test/java/seedu/investigapptor/storage/XmlAdaptedCrimeCaseTest.java
+++ b/src/test/java/seedu/investigapptor/storage/XmlAdaptedCrimeCaseTest.java
@@ -3,7 +3,7 @@ package seedu.investigapptor.storage;
 import static org.junit.Assert.assertEquals;
 import static seedu.investigapptor.storage.XmlAdaptedCrimeCase.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.investigapptor.testutil.TypicalCrimeCases.ALFA;
-import static seedu.investigapptor.testutil.TypicalPersons.BENSON;
+import static seedu.investigapptor.testutil.TypicalInvestigator.BENSON;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,19 +23,19 @@ import seedu.investigapptor.testutil.Assert;
 public class XmlAdaptedCrimeCaseTest {
     private static final String INVALID_NAME = "Project H@ppy";
     private static final String INVALID_DESCRIPTION = " ";
-    private static final XmlAdaptedPerson INVALID_INVESTIGATOR =
-            new XmlAdaptedPerson("R@chel", " ", " ", " ",
-                    BENSON.getTags().stream()
-                            .map(XmlAdaptedTag::new)
-                            .collect(Collectors.toList()));
+    private static final XmlAdaptedInvestigator INVALID_INVESTIGATOR =
+            new XmlAdaptedInvestigator("R@chel", " ", " ", " ", " ",
+                    BENSON.getCrimeCases(), BENSON.getTags().stream()
+                    .map(XmlAdaptedTag::new)
+                    .collect(Collectors.toList()));
     private static final String INVALID_STARTDATE = "123/44/17";
     private static final String INVALID_STATUS = " ";
     private static final String INVALID_TAG = "#Corruption";
 
     private static final String VALID_NAME = ALFA.getCaseName().toString();
     private static final String VALID_DESCRIPTION = ALFA.getDescription().toString();
-    private static final XmlAdaptedPerson VALID_INVESTIGATOR =
-            new XmlAdaptedPerson(ALFA.getCurrentInvestigator());
+    private static final XmlAdaptedInvestigator VALID_INVESTIGATOR =
+            new XmlAdaptedInvestigator(ALFA.getCurrentInvestigator());
     private static final String VALID_STARTDATE = ALFA.getStartDate().date;
     private static final String VALID_STATUS = ALFA.getStatus().toString();
     private static final List<XmlAdaptedTag> VALID_TAGS = ALFA.getTags().stream()

--- a/src/test/java/seedu/investigapptor/testutil/CrimeCaseBuilder.java
+++ b/src/test/java/seedu/investigapptor/testutil/CrimeCaseBuilder.java
@@ -7,7 +7,7 @@ import seedu.investigapptor.model.crimecase.CrimeCase;
 import seedu.investigapptor.model.crimecase.Description;
 import seedu.investigapptor.model.crimecase.StartDate;
 import seedu.investigapptor.model.crimecase.Status;
-import seedu.investigapptor.model.person.Person;
+import seedu.investigapptor.model.person.investigator.Investigator;
 import seedu.investigapptor.model.tag.Tag;
 import seedu.investigapptor.model.util.SampleDataUtil;
 
@@ -23,7 +23,7 @@ public class CrimeCaseBuilder {
 
     private CaseName name;
     private Description description;
-    private Person currentInvestigator;
+    private Investigator currentInvestigator;
     private StartDate startDate;
     private Status status;
     private Set<Tag> tags;
@@ -35,7 +35,7 @@ public class CrimeCaseBuilder {
         status = new Status();
         startDate = new StartDate(DEFAULT_DATE);
         tags = SampleDataUtil.getTagSet(DEFAULT_TAGS);
-        currentInvestigator = new PersonBuilder().withName("Detective Holmes").build();
+        currentInvestigator = new InvestigatorBuilder().withName("Detective Holmes").build();
 
     }
 
@@ -78,7 +78,7 @@ public class CrimeCaseBuilder {
     /**
      * Sets the {@code Person} of the {@code CrimeCase} that we are building.
      */
-    public CrimeCaseBuilder withInvestigator(Person investigator) {
+    public CrimeCaseBuilder withInvestigator(Investigator investigator) {
         this.currentInvestigator = investigator;
         return this;
     }
@@ -110,8 +110,8 @@ public class CrimeCaseBuilder {
     /**
      * Sets the {@code currentInvestigator} of the {@code CrimeCase} that we are building.
      */
-    public CrimeCaseBuilder withCurrentInvestigator(Person investigator) {
-        this.currentInvestigator = new PersonBuilder(investigator).build();
+    public CrimeCaseBuilder withCurrentInvestigator(Investigator investigator) {
+        this.currentInvestigator = new InvestigatorBuilder(investigator).build();
         return this;
     }
 

--- a/src/test/java/seedu/investigapptor/testutil/TypicalCrimeCases.java
+++ b/src/test/java/seedu/investigapptor/testutil/TypicalCrimeCases.java
@@ -96,7 +96,41 @@ public class TypicalCrimeCases {
     }
 
     public static List<CrimeCase> getTypicalCrimeCases() {
-        return new ArrayList<>(Arrays.asList(ALFA, BRAVO, CHARLIE, DELTA, ECHO, FOXTROT, GOLF,
-                ONE, TWO, THREE, FOUR));
+        CrimeCase alfa = new CrimeCaseBuilder().withName("Project Alfa")
+                .withDescription("Murder on the orient express").withStartDate("10/11/2015")
+                .toggleStatus()
+                .withTags("Murder").build();
+        CrimeCase bravo = new CrimeCaseBuilder().withName("Project Bravo Johnny")
+                .withDescription("Crooked house")
+                .withStartDate("12/03/2016")
+                .withTags("Kidnap", "Homicide").build();
+        CrimeCase charlie = new CrimeCaseBuilder().withName("Project Charlie").toggleStatus()
+                .withStartDate("18/01/2012").withDescription("ABC murders").build();
+        CrimeCase delta = new CrimeCaseBuilder().withName("Project Delta Johnny")
+                .withStartDate("27/11/1999").withDescription("Peril at End House").build();
+        CrimeCase echo = new CrimeCaseBuilder().withName("Project Echo")
+                .withStartDate("23/11/1965").withDescription("A study in scarlet").build();
+        CrimeCase foxtrot = new CrimeCaseBuilder().withName("Project Foxtrot").toggleStatus()
+                .withStartDate("09/07/2017").withDescription("The sign of the four").build();
+        CrimeCase golf = new CrimeCaseBuilder().withName("Project Golf")
+                .withStartDate("02/08/2017").withDescription("The hound of the baskervilles").build();
+        CrimeCase one = new CrimeCaseBuilder().withName("Project One")
+                .withDescription("Scary case").withStartDate("10/12/2016")
+                .toggleStatus()
+                .withTags("Murder", "Homicide", "Missing").build();
+        CrimeCase two = new CrimeCaseBuilder().withName("Project Two")
+                .withDescription("Not so scary case").withStartDate("14/12/2016")
+                .toggleStatus()
+                .withTags("Robbery", "Prank", "Kidnap").build();
+        CrimeCase three = new CrimeCaseBuilder().withName("Project Three")
+                .withDescription("Supernatural Case").withStartDate("18/12/2016")
+                .toggleStatus()
+                .withTags("Murder", "Supernatural").build();
+        CrimeCase four = new CrimeCaseBuilder().withName("Project Four")
+                .withDescription("Small case").withStartDate("11/12/2016")
+                .toggleStatus()
+                .withTags("Theft").build();
+        return new ArrayList<>(Arrays.asList(alfa, bravo, charlie, delta, echo, foxtrot, golf,
+                one, two, three, four));
     }
 }


### PR DESCRIPTION
When a CrimeCase is added, the CrimeCase will designate an Investigator as its current investigator.
The current investigator will then add the CrimeCase to its list of active cases.

When converted to XML, all the CrimeCases in the investigator will be converted to hashcode and stored as an array of integer. When converted back to model, it will use the hash to find the correct CrimeCase and add it back into its list.

Add constraint so that a case can only be added to an investigator
Add constraint so that an investigator can only be deleted if he/she has no active case