### PR TITLE
Fixes #124: Add case command (Undo/Redo Bug Fix)

### DIFF
--- a/src/main/java/seedu/investigapptor/logic/commands/AddCaseCommand.java
+++ b/src/main/java/seedu/investigapptor/logic/commands/AddCaseCommand.java
@@ -32,8 +32,8 @@ import seedu.investigapptor.model.tag.Tag;
  */
 public class AddCaseCommand extends UndoableCommand {
 
-    public static final String COMMAND_WORD = "add";
-    public static final String COMMAND_ALIAS = "a";
+    public static final String COMMAND_WORD = "addCase";
+    public static final String COMMAND_ALIAS = "aC";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a case to the investigapptor book. "
             + "Parameters: "

--- a/src/main/java/seedu/investigapptor/logic/commands/AddCaseCommand.java
+++ b/src/main/java/seedu/investigapptor/logic/commands/AddCaseCommand.java
@@ -12,8 +12,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import seedu.investigapptor.commons.core.EventsCenter;
 import seedu.investigapptor.commons.core.Messages;
 import seedu.investigapptor.commons.core.index.Index;
+import seedu.investigapptor.commons.events.ui.SwapTabEvent;
 import seedu.investigapptor.logic.commands.exceptions.CommandException;
 import seedu.investigapptor.model.crimecase.CaseName;
 import seedu.investigapptor.model.crimecase.CrimeCase;
@@ -93,11 +95,11 @@ public class AddCaseCommand extends UndoableCommand {
         requireNonNull(model);
         try {
             model.addCrimeCase(toAdd);
-            return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+            EventsCenter.getInstance().post(new SwapTabEvent(1));
         } catch (DuplicateCrimeCaseException e) {
             throw new CommandException(MESSAGE_DUPLICATE_CASE);
         }
-
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 
     @Override
@@ -108,12 +110,8 @@ public class AddCaseCommand extends UndoableCommand {
             if (investigatorIndex.getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_INVESTIGATOR_DISPLAYED_INDEX);
             }
-            Person investigatorToAdd = lastShownList.get(investigatorIndex.getZeroBased());
-            if (investigatorToAdd instanceof Investigator) {
-                toAdd = createCrimeCase((Investigator) investigatorToAdd);
-            } else {
-                throw new CommandException("Selected personal is not an investigator");
-            }
+            Investigator investigatorToAdd = (Investigator) lastShownList.get(investigatorIndex.getZeroBased());
+            toAdd = createCrimeCase(investigatorToAdd);
         }
     }
 

--- a/src/main/java/seedu/investigapptor/model/Investigapptor.java
+++ b/src/main/java/seedu/investigapptor/model/Investigapptor.java
@@ -311,7 +311,7 @@ public class Investigapptor implements ReadOnlyInvestigapptor {
         final Set<Tag> correctTagReferences = new HashSet<>();
         crimecaseTags.forEach(tag -> correctTagReferences.add(masterTagObjects.get(tag)));
         Investigator investigator = (Investigator) syncWithMasterTagList(crimecase.getCurrentInvestigator());
-        investigator.clear(); // Fix for undo/redo: Clears investigator case list
+        investigator.clearCaseList(); // Fix for undo/redo: Clears investigator case list
         return new CrimeCase(
                 crimecase.getCaseName(), crimecase.getDescription(), investigator,
                 crimecase.getStartDate(), crimecase.getEndDate(), crimecase.getStatus(), correctTagReferences);

--- a/src/main/java/seedu/investigapptor/model/crimecase/UniqueCrimeCaseList.java
+++ b/src/main/java/seedu/investigapptor/model/crimecase/UniqueCrimeCaseList.java
@@ -94,6 +94,14 @@ public class UniqueCrimeCaseList implements Iterable<CrimeCase> {
         return crimeCaseFoundAndDeleted;
     }
 
+    /**
+     * Removes all cases from the list.
+     *
+     */
+    public void removeAll() {
+        internalList.clear();
+    }
+
     public void setCrimeCases(UniqueCrimeCaseList replacement) {
         this.internalList.setAll(replacement.internalList);
     }

--- a/src/main/java/seedu/investigapptor/model/person/investigator/Investigator.java
+++ b/src/main/java/seedu/investigapptor/model/person/investigator/Investigator.java
@@ -104,7 +104,7 @@ public class Investigator extends Person {
         crimeCases.remove(caseToRemove);
     }
 
-    public void clear() {
+    public void clearCaseList() {
         crimeCases.removeAll();
     }
 

--- a/src/main/java/seedu/investigapptor/model/person/investigator/Investigator.java
+++ b/src/main/java/seedu/investigapptor/model/person/investigator/Investigator.java
@@ -104,6 +104,10 @@ public class Investigator extends Person {
         crimeCases.remove(caseToRemove);
     }
 
+    public void clear() {
+        crimeCases.removeAll();
+    }
+
     public ArrayList<Integer> getCaseListHashed() {
         return caseListHashed;
     }


### PR DESCRIPTION
Fixes #124 
- Clears investigator caselist before adding to `CrimeCase` object (now caselist is not stored under the investigator component in the case, only under independent `Investigator` objects)
- Adds case to independent `Investigator` object upon addition of case
- Update AddCaseCommand command word (addCase) and alias (aC)