### PR TITLE
Match investigator as person object instead of just matching their names

### DIFF
--- a/src/main/java/seedu/investigapptor/model/Investigapptor.java
+++ b/src/main/java/seedu/investigapptor/model/Investigapptor.java
@@ -257,7 +257,7 @@ public class Investigapptor implements ReadOnlyInvestigapptor {
         if (key.getCurrentInvestigator() != null) {
             for (Person person : persons) {
                 // Finds the independent Investigator object that was assigned under the case
-                if (key.getCurrentInvestigator().getName().equals(person.getName())) {
+                if (key.getCurrentInvestigator().equals(person)) {
                     Investigator investigator = (Investigator) person;
                     investigator.addCrimeCase(key);
                     break;
@@ -276,7 +276,7 @@ public class Investigapptor implements ReadOnlyInvestigapptor {
         if (key.getCurrentInvestigator() != null) {
             for (Person person : persons) {
                 // Finds the independent Investigator object that was assigned under the case
-                if (key.getCurrentInvestigator().getName().equals(person.getName())) {
+                if (key.getCurrentInvestigator().equals(person)) {
                     Investigator investigator = (Investigator) person;
                     investigator.removeCrimeCase(key);
                     break;


### PR DESCRIPTION
Compare using `Person` `.equals()` method to find investigator when adding to or removing from their case list instead of just comparing the investigator's name